### PR TITLE
switch to use `markdown-reference` instead of `markdown-link` by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ temp
 tmp
 TODO.md
 vendor
+coverage

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function linkify(arr, options) {
     pkg.homepage = utils.homepage(pkg);
 
     var link = typeof options.template !== 'function'
-      ? utils.link(pkg.name, pkg.homepage)
+      ? utils.reference(pkg.name, pkg.homepage)
       : options.template(pkg, options);
 
     if (link) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,7 @@ require('time-diff', 'Time');
 require('log-utils', 'log');
 require('pkg-cache', 'pkgs');
 require('pkg-homepage', 'homepage');
-require('markdown-link', 'link');
+require('markdown-reference', 'reference');
 require = fn;
 
 utils.filter = function(names, cached) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "^2.2.0",
     "lazy-cache": "^1.0.3",
     "log-utils": "^0.1.2",
-    "markdown-link": "^0.1.1",
+    "markdown-reference": "^0.1.0",
     "pkg-cache": "^0.1.3",
     "pkg-homepage": "^0.1.1",
     "time-diff": "^0.2.1"


### PR DESCRIPTION
fixes https://github.com/helpers/helper-reflinks/issues/4
