### PR TITLE
chore: bump version to v0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reflinks",
   "description": "Generate (relative) reference links for a glob of markdown files, allowing you to more easily create references from one file to another.",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "homepage": "https://github.com/jonschlinkert/reflinks",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "jonschlinkert/reflinks",


### PR DESCRIPTION
Bumping version (related to #4), `npm publish` is then required, too.